### PR TITLE
Bumping firebase/php-jwt to version 6.3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "ext-openssl": "*",
-        "firebase/php-jwt": "^5.2",
+        "firebase/php-jwt": "^6.3",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {


### PR DESCRIPTION
Bumping up `firebase/php-jwt` to `^6.3` will allow this package to be compatible with `laravel/passport` `^11.8`.

```
laravel/passport[v11.8.0, ..., v11.8.4] require firebase/php-jwt ^6.3.1
```